### PR TITLE
Added custom parameters for InsertMedia request

### DIFF
--- a/config
+++ b/config
@@ -28,6 +28,13 @@
 ##### Virtual Media #####
 -v VM_URL:https://old-releases.ubuntu.com/releases/22.04/ubuntu-22.04.2-live-server-arm64.iso
 
+# Additional Virtual Media Parameters
+# Following is an example, uncomment and modify the variables as needed by Virtual Media.
+# -v VM_USER:username
+# -v VM_PASSWD:password
+# -v VM_TRANSFER_PROTO_TYPE:NFS
+# -v VM_TRANSFER_METHOD:Stream
+# -v VM_WRITE_PROT:false
 
 ##### Self Declaration For SBMR Interface #####
 # If system supports the compliant interfaces, change corresponding variable to 1.

--- a/lib/resource.robot
+++ b/lib/resource.robot
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,6 +77,13 @@ ${SOL_LOGIN_TIMEOUT}         10 mins
 ${SOL_TYPE}         ipmi
 ${SOL_SSH_PORT}     22
 ${SOL_SSH_CMD}      None
+
+# Virtual Media related parameters
+${VM_USER}                   ${EMPTY}
+${VM_PASSWD}                 ${EMPTY}
+${VM_TRANSFER_PROTO_TYPE}    ${EMPTY}
+${VM_TRANSFER_METHOD}        ${EMPTY}
+${VM_WRITE_PROT}             ${EMPTY}
 
 # PDU related parameters
 ${PDU_TYPE}         ${EMPTY}


### PR DESCRIPTION
- Added check and enable Virtual media support at test start.
- for virtual media test, the InsertMedia action payload can have custom parameters like UserName, Password, TranferProtocol etc.
- Added support for user to optionally configure them  via "config" argument file.

Fixes: #4