### PR TITLE
Removed M3_OOB_1 tag

### DIFF
--- a/redfish/dmtf_tools/Redfish_JsonSchema_ResponseValidator.robot
+++ b/redfish/dmtf_tools/Redfish_JsonSchema_ResponseValidator.robot
@@ -40,7 +40,7 @@ ${command_string}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}Redfish-JsonSchema-Respo
 Test BMC Redfish Using Redfish JsonSchema ResponseValidator
     [Documentation]  Check BMC conformance with JsonSchema files at the DMTF site.
     [Tags]  M2_OOB_1_Redfish_JsonSchema_ResponseValidator
-    ...     M3_OOB_1_Redfish_JsonSchema_ResponseValidator
+
 
     Download DMTF Tool  ${rsv_dir_path}  ${rsv_github_url}  stable_branch=${rsv_revision}
 

--- a/redfish/dmtf_tools/Redfish_Protocol_Validator.robot
+++ b/redfish/dmtf_tools/Redfish_Protocol_Validator.robot
@@ -37,7 +37,7 @@ ${cmd_str_master}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}rf_protocol_validator.py
 Test BMC Redfish Using Redfish Protocol Validator
     [Documentation]  Check conformance with a Redfish service interface.
     [Tags]  M2_OOB_1_Redfish_Protocol_Validator
-    ...     M3_OOB_1_Redfish_Protocol_Validator
+
 
     Download DMTF Tool  ${rsv_dir_path}  ${rsv_github_url}  stable_branch=${rsv_revision}
 

--- a/redfish/dmtf_tools/Redfish_Reference_Checker.robot
+++ b/redfish/dmtf_tools/Redfish_Reference_Checker.robot
@@ -38,7 +38,7 @@ ${command_string}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}RedfishReferenceTool.py
 Test BMC Redfish Reference
     [Documentation]  Checks for valid reference URLs in CSDL XML files.
     [Tags]  M2_OOB_1_Redfish_Reference_Checker
-    ...     M3_OOB_1_Redfish_Reference_Checker
+
 
     ${rc}  ${output}=  Run DMTF Tool  ${rsv_dir_path}  ${command_string}  check_error=1
 

--- a/redfish/dmtf_tools/Redfish_Service_Validator.robot
+++ b/redfish/dmtf_tools/Redfish_Service_Validator.robot
@@ -43,7 +43,7 @@ ${cmd_str_master}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}RedfishServiceValidator.
 Test BMC Redfish Using Redfish Service Validator
     [Documentation]  Check conformance with a Redfish service interface.
     [Tags]  M2_OOB_1_Redfish_Service_Validator
-    ...     M3_OOB_1_Redfish_Service_Validator
+
 
     Download DMTF Tool  ${rsv_dir_path}  ${rsv_github_url}  stable_branch=${rsv_revision}
 

--- a/redfish/test_redfish_boot_device.robot
+++ b/redfish/test_redfish_boot_device.robot
@@ -33,7 +33,7 @@ Suite Teardown   Suite Teardown Execution
 Verify BMC Redfish Boot Source Override with Enabled Mode As Once
     [Documentation]  Verify BMC Redfish Boot Source Override with Enabled Mode As Once.
     [Tags]           M2_OOB_1_Redfish_Boot_Source_As_Once
-    ...              M3_OOB_1_Redfish_Boot_Source_As_Once
+
     [Template]  Set And Verify Boot Source Override
 
     #BootSourceOverrideEnabled    BootSourceOverrideTarget
@@ -45,7 +45,7 @@ Verify BMC Redfish Boot Source Override with Enabled Mode As Once
 Verify BMC Redfish Boot Source Override with Enabled Mode As Continuous
     [Documentation]  Verify BMC Redfish Boot Source Override with Enabled Mode As Continuous.
     [Tags]           M2_OOB_1_Redfish_Boot_Source_As_Continuous
-    ...              M3_OOB_1_Redfish_Boot_Source_As_Continuous
+
     [Template]  Set And Verify Boot Source Override
 
     #BootSourceOverrideEnabled    BootSourceOverrideTarget
@@ -57,7 +57,7 @@ Verify BMC Redfish Boot Source Override with Enabled Mode As Continuous
 Verify BMC Redfish Boot Source Override with Enabled Mode As Disabled
     [Documentation]  Verify BMC Redfish Boot Source Override with Enabled Mode As Disabled.
     [Tags]           M2_OOB_1_Redfish_Boot_Source_As_Disabled
-    ...              M3_OOB_1_Redfish_Boot_Source_As_Disabled
+
 
     Redfish Disable Boot Source
 

--- a/redfish/test_redfish_power_operation.robot
+++ b/redfish/test_redfish_power_operation.robot
@@ -30,7 +30,7 @@ Suite Teardown    Suite Teardown Execution
 Verify Redfish Host GracefulShutdown
     [Documentation]  Verify Redfish host graceful shutdown operation.
     [Tags]  M2_OOB_1_Redfish_Host_GracefulShutdown
-    ...     M3_OOB_1_Redfish_Host_GracefulShutdown
+
 
     # Wait until OS login prompt show up, then issue GracefulShutdown
     Redfish Hard Power Off  stack_mode=skip
@@ -47,7 +47,7 @@ Verify Redfish Host GracefulShutdown
 Verify Redfish Host PowerOn
     [Documentation]  Verify Redfish host power on operation.
     [Tags]  M2_OOB_1_Redfish_Host_PowerOn
-    ...     M3_OOB_1_Redfish_Host_PowerOn
+
 
     Redfish Power On
 
@@ -55,7 +55,7 @@ Verify Redfish Host PowerOn
 Verify Redfish Host PowerOff
     [Documentation]  Verify Redfish host power off operation.
     [Tags]  M2_OOB_1_Redfish_Host_PowerOff
-    ...     M3_OOB_1_Redfish_Host_PowerOff
+
 
     Redfish Hard Power Off
 
@@ -63,7 +63,7 @@ Verify Redfish Host PowerOff
 Verify Redfish Host GracefulRestart
     [Documentation]  Verify Redfish host graceful restart operation.
     [Tags]  M2_OOB_1_Redfish_Host_GracefulRestart
-    ...     M3_OOB_1_Redfish_Host_GracefulRestart
+
 
     # Wait until OS login prompt show up, then issue GracefulRestart
     Redfish Hard Power Off  stack_mode=skip
@@ -80,7 +80,7 @@ Verify Redfish Host GracefulRestart
 Verify Redfish Host ForceRestart
     [Documentation]  Verify Redfish host force restart operation
     [Tags]  M2_OOB_1_Redfish_Host_ForceRestart
-    ...     M3_OOB_1_Redfish_Host_ForceRestart
+
 
     RF SYS ForceRestart
 
@@ -88,7 +88,7 @@ Verify Redfish Host ForceRestart
 Verify Redfish Host PowerCycle
     [Documentation]  Verify Redfish host Power Cycle operation
     [Tags]  M2_OOB_1_Redfish_Host_PowerCycle
-    ...     M3_OOB_1_Redfish_Host_PowerCycle
+
 
     Redfish Power Cycle
 


### PR DESCRIPTION
-M3_OOB_1 is related to IPMI, however in the ACS, we have wrongly tagged redfish OOB tests with it, So the tag is removed.

Fixes : #5