### PR TITLE
Fix : Support for @Redfish.Settings in Redfish URIs

### DIFF
--- a/lib/redfish_plus.py
+++ b/lib/redfish_plus.py
@@ -188,16 +188,6 @@ class redfish_plus(HttpClient):
         if etag is not None:
             headers = {"If-Match": etag}
 
-        # Check if @Redfish.Settings member present
-        if "@Redfish.Settings" in response.dict:
-            # update args with URI found in SettingObject if found else continue
-            try:
-                tmp_args = list(args)
-                tmp_args[0] = response.dict['@Redfish.Settings']['SettingsObject']['@odata.id']
-                args = tuple(tmp_args)
-            except KeyError:
-                pass
-
         quiet = 0
         if MTLS_ENABLED == "True":
             return self.rest_request(

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -290,3 +290,25 @@ def validate_supported_vga_controller(lists):
                 return True
 
     return False
+
+
+def get_value_from_nested_dict(key, nested_dict):
+    r"""
+    Return the key value from the nested dictionary.
+
+    key            Key value of the dictionary to look up.
+    nested_dict    Dictionary data.
+    """
+
+    result = []
+
+    if not isinstance(nested_dict, dict):
+        return result
+
+    for k, v in nested_dict.items():
+        if k == key:
+            result.append(v)
+        elif isinstance(v, dict) and k != key:
+            result += get_value_from_nested_dict(key, v);
+
+    return result


### PR DESCRIPTION
If Redfish URIs support @Redfish.Settings, then it should update the settings via SettingsObject.

Fix from b245064f2d7a4b7823607bff0c554fb1a8731451

Tested and completed on mockup system.