### PR TITLE
Updated deprecated robot keywords

### DIFF
--- a/ipmi/test_ipmi_outband_sol.robot
+++ b/ipmi/test_ipmi_outband_sol.robot
@@ -92,7 +92,7 @@ Verify BSA Compliant UART From Boot Log
     Dictionary Should Contain Key  ${spcr_tty_lists}  ${ttyConsole}[0]
     ...  msg=Failure: Console UART not a BSA compliant UART
 
-    [Return]  ${ttyConsole}[0]
+    RETURN  ${ttyConsole}[0]
 
 
 Suite Setup Execution

--- a/ipmi/test_ipmi_shell_inband_redfish_hi_credentials.robot
+++ b/ipmi/test_ipmi_shell_inband_redfish_hi_credentials.robot
@@ -92,7 +92,7 @@ Check Bootstrapping Account Credential
     Should Not Contain Any  ${string}  ${SPACE}  \\  '  "
     ...  msg=Failure: Credential Contains Invalid Characters
 
-    [Return]  ${string}
+    RETURN  ${string}
 
 
 Redfish Get Credential Bootstrapping Status
@@ -106,7 +106,7 @@ Redfish Get Credential Bootstrapping Status
     # Assume: only one host interface
     ${prop}=  Redfish.Get Properties  ${interface}[0]
 
-    [Return]  ${prop["CredentialBootstrapping"]["Enabled"]}
+    RETURN  ${prop["CredentialBootstrapping"]["Enabled"]}
 
 
 Redfish Set Credential Bootstrapping Status
@@ -125,5 +125,5 @@ Redfish Set Credential Bootstrapping Status
     Redfish.Patch  ${interface}[0]  body=&{payload}
     ...  valid_status_codes=[${HTTP_OK}, ${HTTP_NO_CONTENT}]
 
-    [Return]  ${status}
+    RETURN  ${status}
 

--- a/lib/bmc_ldap_utils.robot
+++ b/lib/bmc_ldap_utils.robot
@@ -26,7 +26,7 @@ Get LDAP Configuration Using Redfish
     # ldap_type  The LDAP type ("ActiveDirectory" or "LDAP").
 
     ${ldap_config}=  Redfish.Get Properties  ${REDFISH_BASE_URI}AccountService
-    [Return]  ${ldap_config["${ldap_type}"]}
+    RETURN  ${ldap_config["${ldap_type}"]}
 
 
 Get LDAP Privilege And Group Name Via Redfish
@@ -72,7 +72,7 @@ Get LDAP Privilege And Group Name Via Redfish
       Append To List  ${ldap_group_names}  ${ldap_config["RemoteRoleMapping"][${i}]["RemoteGroup"]}
     END
 
-    [Return]  ${ldap_group_names}
+    RETURN  ${ldap_group_names}
 
 
 Create LDAP Configuration

--- a/lib/bmc_network_security_utils.robot
+++ b/lib/bmc_network_security_utils.robot
@@ -43,7 +43,7 @@ Send Network Packets And Get Packet Loss
     ${cmd_buf}=  Set Variable  --delay ${delay} ${host} -c ${num} --${packet_type} ${cmd_suffix}
 
     ${nping_result}=  Nping  ${cmd_buf}
-    [Return]   ${nping_result['percent_lost']}
+    RETURN   ${nping_result['percent_lost']}
 
 
 Send Network Packets With Flags And Verify Stability

--- a/lib/bmc_redfish_utils.robot
+++ b/lib/bmc_redfish_utils.robot
@@ -181,7 +181,7 @@ Get Session With Client Id
         ...    Append To List  ${client_id_sessions}  ${session}
     END
 
-    [Return]  ${client_id_sessions}
+    RETURN  ${client_id_sessions}
 
 
 Get Valid FRUs
@@ -197,7 +197,7 @@ Get Valid FRUs
     ...  /redfish/v1/Systems/${SYSTEM_ID}/${fru_type}  return_json=0
     ${fru_records}=  Filter Struct  ${fru_records}  [('State', 'Enabled'), ('Health', 'OK')]
 
-    [Return]  ${fru_records}
+    RETURN  ${fru_records}
 
 
 Get Num Valid FRUs
@@ -210,7 +210,7 @@ Get Num Valid FRUs
     ${fru_records}=  Get Valid FRUs  ${fru_type}
     ${num_valid_frus}=  Get length  ${fru_records}
 
-    [Return]  ${num_valid_frus}
+    RETURN  ${num_valid_frus}
 
 
 Verify Valid Records
@@ -249,7 +249,7 @@ Verify Valid Records
     ...  [('Health', '^OK$'), ('State', '^Enabled$'), ('${reading_type}', '')]  regex=1  invert=1
     Valid Length  invalid_records  max_length=0
 
-    [Return]  ${records}
+    RETURN  ${records}
 
 
 Redfish Create User
@@ -293,7 +293,7 @@ Get User Role
     ${role_config}=  Redfish_Utils.Get Attribute
     ...  ${REDFISH_ACCOUNTS_URI}${user_name}  RoleId
 
-    [Return]  ${role_config}
+    RETURN  ${role_config}
 
 
 Create Users With Different Roles
@@ -389,7 +389,7 @@ Get BMC Last Reset Time
 
     ${last_reset_time}=  Redfish.Get Attribute  /redfish/v1/Managers/${BMC_ID}  LastResetTime
 
-    [Return]  ${last_reset_time}
+    RETURN  ${last_reset_time}
 
 
 Is Redfish Standard ODataType
@@ -407,4 +407,4 @@ Is Redfish Standard ODataType
     Run Keyword If  '${found}'=='${FALSE}'
     ...  Log To Console  Info: Skip ${odata_type}
 
-    [Return]  ${found}
+    RETURN  ${found}

--- a/lib/common_utils.robot
+++ b/lib/common_utils.robot
@@ -193,7 +193,7 @@ Check If warmReset is Initiated
     ${alive}=   Run Keyword and Return Status
     ...    Open Connection And Log In
     Return From Keyword If   '${alive}' == '${False}'    ${False}
-    [Return]    ${True}
+    RETURN    ${True}
 
 
 Create OS Console Command String
@@ -214,7 +214,7 @@ Create OS Console Command String
     ${cmd}=  Catenate  ${ssh_pw_file_path} ${BMC_PASSWORD} -p ${HOST_SOL_PORT}
     ...  -o "StrictHostKeyChecking no" ${BMC_USERNAME}@${BMC_HOST} ${BMC_CONSOLE_CLIENT}
 
-    [Return]  ${cmd.strip()}
+    RETURN  ${cmd.strip()}
 
 
 Get SOL Console Pid
@@ -289,7 +289,7 @@ Stop SOL Console Logging
     ...  Cmd Fnc  cat ${log_file_path} 2>/dev/null  quiet=${loc_quiet}
     ...  print_output=${0}  show_err=${0}
 
-    [Return]  ${output}
+    RETURN  ${output}
 
 
 Start SOL Console Logging
@@ -330,7 +330,7 @@ Start SOL Console Logging
     Wait Until Keyword Succeeds  10 seconds  0 seconds
     ...   Get SOL Console Pid  ${1}  ${log_file_path}
 
-    [Return]  ${log_output}
+    RETURN  ${log_output}
 
 
 Mac Address To Hex String
@@ -347,7 +347,7 @@ Mac Address To Hex String
     # i_macaddress   The MAC address.
 
     ${mac_hex}=  Catenate  0x${i_macaddress.replace(':', ' 0x')}
-    [Return]    ${mac_hex}
+    RETURN    ${mac_hex}
 
 
 IP Address To Hex String
@@ -370,20 +370,20 @@ IP Address To Hex String
     END
     ${ip_hex}=  Catenate    @{ip}
 
-    [Return]    ${ip_hex}
+    RETURN    ${ip_hex}
 
 
 Redfish Get BMC Version
     [Documentation]  Get BMC version via Redfish.
 
     ${output}=  Redfish.Get Attribute  ${REDFISH_BASE_URI}Managers/${BMC_ID}  FirmwareVersion
-    [Return]  ${output}
+    RETURN  ${output}
 
 Redfish Get Host Version
     [Documentation]  Get host version via Redfish.
 
     ${output}=  Redfish.Get Attribute  ${REDFISH_BASE_URI}Systems/${SYSTEM_ID}  BiosVersion
-    [Return]  ${output}
+    RETURN  ${output}
 
 
 Validate IP On BMC

--- a/lib/dmtf_redfishtool_utils.robot
+++ b/lib/dmtf_redfishtool_utils.robot
@@ -43,7 +43,7 @@ Redfishtool Get
     ...  ELSE
     ...    Is HTTP error Expected  ${cmd_output}  ${expected_error}
 
-    [Return]  ${cmd_output}
+    RETURN  ${cmd_output}
 
 
 Redfishtool Patch
@@ -63,7 +63,7 @@ Redfishtool Patch
     ...  ELSE
     ...    Is HTTP error Expected  ${cmd_output}  ${expected_error}
 
-    [Return]  ${cmd_output}
+    RETURN  ${cmd_output}
 
 
 Redfishtool Post
@@ -84,7 +84,7 @@ Redfishtool Post
     ...  ELSE
     ...    Is HTTP error Expected  ${cmd_output}  ${expected_error}
 
-    [Return]  ${cmd_output}
+    RETURN  ${cmd_output}
 
 
 Redfishtool Delete
@@ -103,7 +103,7 @@ Redfishtool Delete
     ...  ELSE
     ...    Is HTTP error Expected  ${cmd_output}  ${expected_error}
 
-    [Return]  ${cmd_output}
+    RETURN  ${cmd_output}
 
 
 Is HTTP error Expected

--- a/lib/dmtf_tools_utils.robot
+++ b/lib/dmtf_tools_utils.robot
@@ -51,7 +51,7 @@ Run DMTF Tool
 
     ${rc}  ${output}=  Shell Cmd  ${command_string}  ignore_err=${check_error}
     Log  ${output}
-    [Return]  ${rc}  ${output}
+    RETURN  ${rc}  ${output}
 
 
 Redfish Service Validator Result

--- a/lib/dump_utils.robot
+++ b/lib/dump_utils.robot
@@ -48,7 +48,7 @@ Get Redfish BMC Dump Log Entries
 
      ${resp}=  Redfish.Get  ${REDFISH_DUMP_URI}
 
-     [Return]  ${resp.dict}
+     RETURN  ${resp.dict}
 
 
 Redfish Delete All System Dumps
@@ -80,7 +80,7 @@ Initiate BMC Dump Using Redfish And Return Task Id
      # "TaskState": "Running",
      # "TaskStatus": "OK"
 
-     [Return]  ${resp.dict['Id']}
+     RETURN  ${resp.dict['Id']}
 
 Create User Initiated BMC Dump Via Redfish
     [Documentation]  Generate user initiated BMC dump via Redfish and return the dump id number (e.g., "5").
@@ -127,7 +127,7 @@ Create User Initiated BMC Dump Via Redfish
     #       "/redfish/v1/Managers/${BMC_ID}/LogServices/Dump/Actions/LogService.CollectDiagnosticData"
     # }
 
-    [Return]  ${task_dict["Payload"]["HttpHeaders"][-1].split("/")[-1]}
+    RETURN  ${task_dict["Payload"]["HttpHeaders"][-1].split("/")[-1]}
 
 
 Get Dump ID
@@ -156,7 +156,7 @@ Get Dump ID
     ${task_dict}=  Redfish.Get Properties  /redfish/v1/TaskService/Tasks/${task_id}
     ${key}  ${value}=  Set Variable  ${task_dict["Payload"]["HttpHeaders"][-1].split(":")}
     Run Keyword If  '${key}' != 'Location'  Fail
-    [Return]  ${value.strip('/').split('/')[-1]}
+    RETURN  ${value.strip('/').split('/')[-1]}
 
 Get Task Status
     [Documentation]  Return task status.
@@ -166,7 +166,7 @@ Get Task Status
     # task_id        Task ID.
 
     ${resp}=  Redfish.Get Properties  /redfish/v1/TaskService/Tasks/${task_id}
-    [Return]  ${resp['TaskState']}
+    RETURN  ${resp['TaskState']}
 
 Check Task Completion
     [Documentation]  Check if the task is complete.

--- a/lib/energy_scale_utils.robot
+++ b/lib/energy_scale_utils.robot
@@ -39,7 +39,7 @@ Get System Power Cap Limit
 
     ${power_limit_watts}=  Redfish.Get Attribute  ${power_cap_uri}   PowerLimitWatts
 
-    [return]  ${power_limit_watts}
+    RETURN  ${power_limit_watts}
 
 
 DCMI Power Get Limits
@@ -62,7 +62,7 @@ DCMI Power Get Limits
     ${output}=  Remove String  ${output}  milliseconds
     ${output}=  Remove String  ${output}  seconds
     &{limits}=  Key Value Outbuf To Dict  ${output}
-    [Return]  &{limits}
+    RETURN  &{limits}
 
 
 Get DCMI Power Limit
@@ -71,7 +71,7 @@ Get DCMI Power Limit
 
     &{limits}=  DCMI Power Get Limits
     ${power_setting}=  Get From Dictionary  ${limits}  power_limit
-    [Return]  ${power_setting}
+    RETURN  ${power_setting}
 
 
 Set DCMI Power Limit And Verify

--- a/lib/event_notification_utils.robot
+++ b/lib/event_notification_utils.robot
@@ -38,5 +38,5 @@ Get Event Subscription IDs
         Append To List  ${subscription_ids}
         ...  ${subscription['@odata.id'].split("/redfish/v1/EventService/Subscriptions/")[-1]}
     END
-    [Return]  ${subscription_ids}
+    RETURN  ${subscription_ids}
 

--- a/lib/ipmi_client.robot
+++ b/lib/ipmi_client.robot
@@ -54,7 +54,7 @@ Run IPMI Command
     ...  ELSE IF  '${IPMI_COMMAND}' == 'Inband'
     ...    Run Inband IPMI Raw Command  ${command}
     ...  ELSE  Fail  msg=Invalid IPMI Command type provided: ${IPMI_COMMAND}
-    [Return]  ${resp}
+    RETURN  ${resp}
 
 
 Run IPMI Standard Command
@@ -76,7 +76,7 @@ Run IPMI Standard Command
     ...  ELSE IF  '${IPMI_COMMAND}' == 'Inband'
     ...    Run Inband IPMI Standard Command  ${command}  ${fail_on_err}
     ...  ELSE  Fail  msg=Invalid IPMI Command type provided : ${IPMI_COMMAND}
-    [Return]  ${resp}
+    RETURN  ${resp}
 
 
 Run Inband IPMI Raw Command
@@ -99,7 +99,7 @@ Run Inband IPMI Raw Command
     ${stdout}  ${stderr}=  Execute Command  ${ipmi_cmd}  return_stderr=True
     Return From Keyword If  ${fail_on_err} == ${0}  ${stderr}
     Should Be Empty  ${stderr}  msg=${stdout}
-    [Return]  ${stdout}
+    RETURN  ${stdout}
 
 
 Run Inband IPMI Standard Command
@@ -125,7 +125,7 @@ Run Inband IPMI Standard Command
     ${stdout}  ${stderr}=  Execute Command  ${ipmi_cmd}  return_stderr=True
     Return From Keyword If  ${fail_on_err} == ${0}  ${stderr}
     Should Be Empty  ${stderr}  msg=${stdout}
-    [Return]  ${stdout}
+    RETURN  ${stdout}
 
 
 Run External IPMI Standard Command
@@ -150,7 +150,7 @@ Run External IPMI Standard Command
     ${rc}  ${output}=  Run And Return RC and Output  ${ipmi_cmd}
     Return From Keyword If  ${fail_on_err} == ${0}  ${output}
     Should Be Equal  ${rc}  ${expected_rc}  msg=${output}
-    [Return]  ${output}
+    RETURN  ${output}
 
 
 Run External IPMI Raw Command
@@ -164,7 +164,7 @@ Run External IPMI Raw Command
 
     ${output}=  Run External IPMI Standard Command
     ...  raw ${command}  ${fail_on_err}  &{options}
-    [Return]  ${output}
+    RETURN  ${output}
 
 
 Check If IPMI Tool Exist
@@ -219,7 +219,7 @@ Deactivate SOL Via IPMI
     # Logging SOL output for debug purpose.
     Log  ${output}
 
-    [Return]  ${output}
+    RETURN  ${output}
 
 
 Byte Conversion
@@ -265,7 +265,7 @@ Byte Conversion
     #   Equivalent dbus-send argument for smaller IPMI raw command:
     #   byte:0x00 byte:0x06 byte:0x00 byte:0x36
     Run Keyword if   ${argLength} == 9     Return from Keyword    ${valueinBytesWithoutArray}
-    [Return]    ${valueinBytesWithArray}
+    RETURN    ${valueinBytesWithArray}
 
 
 Set NetFn Byte
@@ -334,7 +334,7 @@ Get Host State Via External IPMI
     Should Not Contain  ${output}  Error
     ${output}=  Fetch From Right  ${output}  ${SPACE}
 
-    [Return]  ${output}
+    RETURN  ${output}
 
 
 Set BMC Network From Host
@@ -401,7 +401,7 @@ Create Random IPMI User
     ${random_username}=  Generate Random String  8  [LETTERS]
     ${random_userid}=  Evaluate  random.randint(2, 15)  modules=random
     IPMI Create User  ${random_userid}  ${random_username}
-    [Return]  ${random_userid}  ${random_username}
+    RETURN  ${random_userid}  ${random_username}
 
 
 Delete Created User
@@ -469,7 +469,7 @@ Create SEL
 
     Should Not Contain  ${resp}  00 00  msg=SEL not created.
 
-    [Return]  ${resp}
+    RETURN  ${resp}
 
 
 Fetch One Threshold Sensor From Sensor List
@@ -492,7 +492,7 @@ Fetch One Threshold Sensor From Sensor List
 
     ${random_sensor_name}=  Evaluate  random.choice(${sensor_name_list})  random
 
-    [Return]  ${random_sensor_name}
+    RETURN  ${random_sensor_name}
 
 Fetch Sensor Details From SDR
     [Documentation]  Identify the sensors from sdr get and fetch sensor details required.
@@ -512,7 +512,7 @@ Fetch Sensor Details From SDR
     ...  case-insensitive
     ${setting_status}=  Fetch From Right  ${setting_line}  :${SPACE}
 
-    [Return]  ${setting_status}
+    RETURN  ${setting_status}
 
 
 Get Bytes From SDR Sensor
@@ -528,7 +528,7 @@ Get Bytes From SDR Sensor
     ${sensor_hex}=  Replace String  ${sensor_detail[1]}  )  ${EMPTY}
     ${sensor_hex}=  Zfill Data  ${sensor_hex}  2
 
-    [Return]  ${sensor_hex}
+    RETURN  ${sensor_hex}
 
 
 Get Current Date from BMC
@@ -548,7 +548,7 @@ Get Current Date from BMC
     ${date}=  Convert Date  ${date}  date_format=%b %d %H:%M:%S %Y
     ...  result_format=%m/%d/%Y %H:%M:%S  exclude_millis=True
 
-    [Return]   ${date}
+    RETURN   ${date}
 
 
 Get SEL Info Via IPMI
@@ -569,7 +569,7 @@ Get SEL Info Via IPMI
     ...  raw ${IPMI_RAW_CMD['SEL_entry']['SEL_info'][0]}
     ${resp}=  Split String  ${resp}
 
-    [Return]  ${resp}
+    RETURN  ${resp}
 
 
 Verify Invalid IPMI Command
@@ -613,7 +613,7 @@ Identify Request Data
     # ${hex1} will contains the data to write for fru in list.
     # ${hex2} will contains the data to verify fru after write operation completed.
 
-    [Return]  ${hex1}  ${hex2}
+    RETURN  ${hex1}  ${hex2}
 
 
 Check IPMI SOL Output Content

--- a/lib/ipmi_shell_client.robot
+++ b/lib/ipmi_shell_client.robot
@@ -48,7 +48,7 @@ Run Shell Inband IPMI Raw Command
     Return From Keyword If  ${fail_on_err} == ${0}  ${stderr}
     Should Be Empty  ${stderr}  msg=${stdout}
 
-    [Return]  ${stdout}
+    RETURN  ${stdout}
 
 
 Run Shell Inband IPMI Standard Command
@@ -66,7 +66,7 @@ Run Shell Inband IPMI Standard Command
     ${rc}  ${stdout}  ${stderr}=  Shell Cmd  ${ipmi_cmd}  return_stderr=True
     Return From Keyword If  ${fail_on_err} == ${0}  ${stderr}
     Should Be Empty  ${stderr}  msg=${stdout}
-    [Return]  ${stdout}
+    RETURN  ${stdout}
 
 
 Check If IPMI Tool Exist

--- a/lib/list_utils.robot
+++ b/lib/list_utils.robot
@@ -38,7 +38,7 @@ Smart Combine Lists
 
     ${new_list}=  Combine Lists  @{lists}
 
-    [Return]  ${new_list}
+    RETURN  ${new_list}
 
 
 Intersect Lists
@@ -66,7 +66,7 @@ Intersect Lists
 
     @{intersected_list}=  Remove Duplicates  ${intersected_list}
 
-    [Return]  @{intersected_list}
+    RETURN  @{intersected_list}
 
 
 Subtract Lists
@@ -86,4 +86,4 @@ Subtract Lists
         ...  Append To List  ${diff_list}  ${item}
     END
 
-    [Return]  ${diff_list}
+    RETURN  ${diff_list}

--- a/lib/logging_utils.robot
+++ b/lib/logging_utils.robot
@@ -44,7 +44,7 @@ Filter Expected Logging Events
     ${all_event_list}=  Get Redfish Event Logs
     Remove Values From List  ${all_event_list}  ${expected_event}
 
-    [Return]  ${all_event_list}
+    RETURN  ${all_event_list}
 
 
 Get IPMI SEL Setting
@@ -59,7 +59,7 @@ Get IPMI SEL Setting
     ...  case-insensitive
     ${setting_status}=  Fetch From Right  ${setting_line}  :${SPACE}
 
-    [Return]  ${setting_status}
+    RETURN  ${setting_status}
 
 
 Get Event Logs
@@ -88,7 +88,7 @@ Get Event Logs
     #}
 
     ${members}=  Redfish.Get Attribute  ${EVENT_LOG_URI}Entries  Members
-    [Return]  ${members}
+    RETURN  ${members}
 
 
 Get Redfish Event Logs
@@ -112,7 +112,7 @@ Get Redfish Event Logs
     Return From Keyword If  '${num_filter_struct_args}' == '${0}'  &{packed_dict}
     ${filtered_error_logs}=  Filter Struct  ${packed_dict}  &{filter_struct_args}
 
-    [Return]  ${filtered_error_logs}
+    RETURN  ${filtered_error_logs}
 
 
 Get Event Logs Not Ok
@@ -120,7 +120,7 @@ Get Event Logs Not Ok
 
     ${members}=  Get Event Logs
     ${severe_logs}=  Evaluate  [elog for elog in $members if elog['Severity'] != 'OK']
-    [Return]  ${severe_logs}
+    RETURN  ${severe_logs}
 
 
 Get Number Of Event Logs
@@ -128,7 +128,7 @@ Get Number Of Event Logs
 
     ${members}=  Get Event Logs
     ${num_members}=  Get Length  ${members}
-    [Return]  ${num_members}
+    RETURN  ${num_members}
 
 
 Redfish Purge Event Log
@@ -180,4 +180,4 @@ Redfish Get PostCodes
     ${members}=  Redfish.Get Attribute  /redfish/v1/Systems/${SYSTEM_ID}/LogServices/PostCodes/Entries
     ...  Members  valid_status_codes=[${HTTP_OK}, ${HTTP_NO_CONTENT}]
 
-    [Return]  ${members}
+    RETURN  ${members}

--- a/lib/redfish_request.robot
+++ b/lib/redfish_request.robot
@@ -42,7 +42,7 @@ Redfish Generic Login Request
     ${resp}=  Request_Login  headers=None  url=${uri}  credential=${data}
     Should Be Equal As Strings  ${resp.status_code}  ${HTTP_CREATED}
 
-    [Return]  ${resp}
+    RETURN  ${resp}
 
 
 Redfish Generic Session Request
@@ -67,4 +67,4 @@ Redfish Generic Session Request
     Set Global Variable  ${active_session_info}  ${session_dict}
     Append To List  ${session_dict_list}  ${session_dict}
 
-    [Return]  ${session_dict}
+    RETURN  ${session_dict}

--- a/lib/resource.robot
+++ b/lib/resource.robot
@@ -154,14 +154,14 @@ ${M2_RAS_1_2_Function_Declaration}       0
 Get Inventory Schema
     [Documentation]  Get inventory schema.
     [Arguments]    ${machine}
-    [Return]    &{INVENTORY}[${machine}]
+    RETURN    &{INVENTORY}[${machine}]
 
 Get Inventory Items Schema
     [Documentation]  Get inventory items schema.
     [Arguments]    ${machine}
-    [Return]    &{INVENTORY_ITEMS}[${machine}]
+    RETURN    &{INVENTORY_ITEMS}[${machine}]
 
 Get Sensor Schema
     [Documentation]  Get sensors schema.
     [Arguments]    ${machine}
-    [Return]    &{SENSORS}[${machine}]
+    RETURN    &{SENSORS}[${machine}]

--- a/lib/utils.robot
+++ b/lib/utils.robot
@@ -98,7 +98,7 @@ Login To OS Host
 
     SSHLibrary.Open Connection  ${os_host}
     ${resp}=  SSHLibrary.Login  ${os_username}  ${os_password}
-    [Return]  ${resp}
+    RETURN  ${resp}
 
 
 Initiate OS Host Reboot
@@ -147,14 +147,14 @@ Redfish Get Power Restore Policy
     [Documentation]  Returns the BMC power restore policy.
 
     ${power_restore_policy}=  Redfish.Get Attribute  /redfish/v1/Systems/${SYSTEM_ID}  PowerRestorePolicy
-    [Return]  ${power_restore_policy}
+    RETURN  ${power_restore_policy}
 
 
 Redfish Get Auto Reboot
     [Documentation]  Returns auto reboot setting.
 
     ${resp}=  Redfish.Get Attribute  /redfish/v1/Systems/${SYSTEM_ID}  Boot
-    [Return]  ${resp["AutomaticRetryConfig"]}
+    RETURN  ${resp["AutomaticRetryConfig"]}
 
 
 Redfish Set Power Restore Policy
@@ -248,7 +248,7 @@ Get Task State From File
     ...  json.load(open('${code_base_dir_path}data/task_state.json'))  modules=json
     Rprint Vars  task_state
 
-    [Return]  ${task_state}
+    RETURN  ${task_state}
 
 
 Redfish Set Boot Default
@@ -297,7 +297,7 @@ Get Redfish Settings Object Uri
     ...  ELSE
     ...      Set Variable  ${uris}[0]
 
-    [Return]  ${uri}
+    RETURN  ${uri}
 
 
 Redfish Set Boot Source
@@ -376,7 +376,7 @@ Redfish Get BMC State
     # },
 
     ${status}=  Redfish.Get Attribute  /redfish/v1/Managers/${BMC_ID}  Status
-    [Return]  ${status["State"]}
+    RETURN  ${status["State"]}
 
 
 Redfish Get Host State
@@ -393,7 +393,7 @@ Redfish Get Host State
     # },
 
     ${chassis}=  Redfish.Get Properties  /redfish/v1/Chassis/${CHASSIS_ID}
-    [Return]  ${chassis["PowerState"]}  ${chassis["Status"]["State"]}
+    RETURN  ${chassis["PowerState"]}  ${chassis["Status"]["State"]}
 
 
 Redfish Get Boot Progress
@@ -417,7 +417,7 @@ Redfish Get Boot Progress
     ...  ELSE
     ...    Set Variable  ${resp["PowerState"]}
 
-    [Return]  ${LastState}  ${resp["Status"]["State"]}
+    RETURN  ${LastState}  ${resp["Status"]["State"]}
 
 
 Redfish Get States
@@ -444,7 +444,7 @@ Redfish Get States
 
     Redfish.Delete  ${session}
 
-    [Return]  ${states}
+    RETURN  ${states}
 
 
 Redfish Delete All Sessions
@@ -565,7 +565,7 @@ Get BIOS Attribute
     ${systems}=  Redfish_Utils.Get Member List  /redfish/v1/Systems
     ${bios_attr_dict}=  Redfish.Get Attribute  ${systems[0]}/Bios  Attributes
 
-    [Return]  ${bios_attr_dict}
+    RETURN  ${bios_attr_dict}
 
 
 Set BIOS Attribute

--- a/redfish/dmtf_tools/Redfish_Interop_Validator.robot
+++ b/redfish/dmtf_tools/Redfish_Interop_Validator.robot
@@ -39,7 +39,7 @@ ${profile_dir_path}    HWMgmt-OCP-profiles
 ${profile_github_url}  https://github.com/opencomputeproject/HWMgmt-OCP-Profiles
 
 
-*** Test Case ***
+*** Test Cases ***
 
 Test BMC Redfish Using Redfish Interop Validator On OCP Baseline Profile
     [Documentation]  Check conformance based on the BMC Interoperability profile.

--- a/redfish/dmtf_tools/Redfish_JsonSchema_ResponseValidator.robot
+++ b/redfish/dmtf_tools/Redfish_JsonSchema_ResponseValidator.robot
@@ -35,7 +35,7 @@ ${validator_dir}   ${OUTPUT_DIR}${/}${rsv_dir_path}
 ${command_string}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}Redfish-JsonSchema-ResponseValidator.py
 ...                -r https://${BMC_HOST} -u ${BMC_USERNAME} -p ${BMC_PASSWORD} -S -v
 
-*** Test Case ***
+*** Test Cases ***
 
 Test BMC Redfish Using Redfish JsonSchema ResponseValidator
     [Documentation]  Check BMC conformance with JsonSchema files at the DMTF site.

--- a/redfish/dmtf_tools/Redfish_Mockup_Creator.robot
+++ b/redfish/dmtf_tools/Redfish_Mockup_Creator.robot
@@ -34,7 +34,7 @@ ${cmd_str_master}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}redfishMockupCreate.py
 ...                -r https://${BMC_HOST}:${HTTPS_PORT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD}
 ...                -S --Dir ${mockup_dir} --quiet --maxlogentries 10
 
-*** Test Case ***
+*** Test Cases ***
 
 Test BMC Redfish Using Redfish Mockup Creator
     [Documentation]  Collect Redfish APIs for debugging via Redfish-Mockup-Creator.

--- a/redfish/dmtf_tools/Redfish_Protocol_Validator.robot
+++ b/redfish/dmtf_tools/Redfish_Protocol_Validator.robot
@@ -32,7 +32,7 @@ ${cmd_str_master}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}rf_protocol_validator.py
 ...                --report-dir ${EXECDIR}${/}logs${/}redfish-protocol-validator
 ...                --no-cert-check
 
-*** Test Case ***
+*** Test Cases ***
 
 Test BMC Redfish Using Redfish Protocol Validator
     [Documentation]  Check conformance with a Redfish service interface.

--- a/redfish/dmtf_tools/Redfish_Reference_Checker.robot
+++ b/redfish/dmtf_tools/Redfish_Reference_Checker.robot
@@ -33,7 +33,7 @@ ${rsv_revision}           1.0.1
 ${command_string}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}RedfishReferenceTool.py
 ...                --nochkcert 'https://${BMC_HOST}:${HTTPS_PORT}/redfish/v1/$metadata'
 
-*** Test Case ***
+*** Test Cases ***
 
 Test BMC Redfish Reference
     [Documentation]  Checks for valid reference URLs in CSDL XML files.

--- a/redfish/dmtf_tools/Redfish_Service_Validator.robot
+++ b/redfish/dmtf_tools/Redfish_Service_Validator.robot
@@ -38,7 +38,7 @@ ${cmd_str_master}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}RedfishServiceValidator.
 ...                -p ${BMC_PASSWORD} --logdir ${OUTPUT_DIR}${/}redfish-service-validator
 ...                --debugging
 
-*** Test Case ***
+*** Test Cases ***
 
 Test BMC Redfish Using Redfish Service Validator
     [Documentation]  Check conformance with a Redfish service interface.

--- a/redfish/dmtf_tools/Redfish_Usecase_Checkers.robot
+++ b/redfish/dmtf_tools/Redfish_Usecase_Checkers.robot
@@ -61,7 +61,7 @@ ${power_on_timeout}       15 mins
 ${power_off_timeout}      15 mins
 ${state_change_timeout}   3 mins
 
-*** Test Case ***
+*** Test Cases ***
 
 Test BMC Redfish Account Management
     [Documentation]  Check Account Management with a Redfish interface.


### PR DESCRIPTION
 - replaced '[Return]' with 'RETURN' and '*** Test Case ***' with plural '*** Test Cases ***'.
 - Above mentioned keywords are deprecated with robotframework >= 7.0

Fixes : #19