### PR TITLE
Fixed log path for SOL output directory

### DIFF
--- a/config
+++ b/config
@@ -7,8 +7,8 @@
 -v SYSTEM_ID:system
 -v CHASSIS_ID:chassis
 
+# relative or absolute path of logs directory
 --outputdir=logs
-
 
 ##### SOL Information #####
 # Default SOL_TYPE as ipmi sol.

--- a/lib/resource.robot
+++ b/lib/resource.robot
@@ -66,7 +66,7 @@ ${IPMI_DELAY}         ${1}
 ${IPMI_OPTIONS_EFIBOOT}       ${EMPTY}
 
 # Log default path for IPMI SOL.
-${IPMI_SOL_LOG_FILE}    ${EXECDIR}${/}logs${/}sol_${BMC_HOST}
+${IPMI_SOL_LOG_FILE}    ${OUTPUT_DIR}${/}sol_${BMC_HOST}
 
 # IPMI SOL console output types/parameters to verify.
 ${SOL_BIOS_OUTPUT}          ${EMPTY}


### PR DESCRIPTION
 - using ${OUTPUT DIR} automatic variable to get absolute path to log dir passed via --outputdir in config file.

Fixes: #20