### PR TITLE
SBMR Errata 600, 652 & 653 changes

### DIFF
--- a/ipmi/test_ipmi_outband_boot_select.robot
+++ b/ipmi/test_ipmi_outband_boot_select.robot
@@ -41,8 +41,6 @@ Test IPMI Out-of-Band Boot Device Selection
     none
     pxe
     disk
-    bios
-
 
 *** Keywords ***
 

--- a/ipmi/test_ipmi_shell_inband_interface_check.robot
+++ b/ipmi/test_ipmi_shell_inband_interface_check.robot
@@ -43,7 +43,6 @@ Test Host IPMI Inband Interface Functionality
 
 Test Host IPMI Inband Interface Interrupt
     [Documentation]  Verify IPMI Inband Interface Interrupt on Host
-    [Tags]  M21_IB_2_IPMI_SSIF_Interrupt
 
     ${rc}  ${stdout}  ${stderr}=  Shell Cmd  ${DMIDECODE_CMD_38}  return_stderr=True
 

--- a/ipmi/test_ipmi_shell_inband_redfish_hi_credentials.robot
+++ b/ipmi/test_ipmi_shell_inband_redfish_hi_credentials.robot
@@ -27,7 +27,7 @@ Test Teardown    Sleep  ${IPMI_DELAY}
 Test Host IPMI Inband Redfish Host Get Manager Certificate Fingerprint
     [Documentation]  Test IPMI Inband Redfish Host Get Manager Certificate
     ...              Fingerprint on Host
-    [Tags]  M21_IPMI_1_Redfish_Host_Certificate_Fingerprint
+    [Tags]  M21_IPMI_1_IPMI_8_Redfish_Host_Certificate_Fingerprint
 
     # Get Certificate Number 1
     ${ipmi_output}=  Run Shell Inband IPMI Raw Command  0x2c 0x01 0x52 0x1
@@ -46,7 +46,7 @@ Test Host IPMI Inband Redfish Host Get Manager Certificate Fingerprint
 Test Host IPMI Inband Redfish Host Get Account Credential
     [Documentation]  Test IPMI Inband Redfish Host Get Account Credential
     ...              on Host
-    [Tags]  M21_IPMI_1_Redfish_Host_Get_Account_Credential
+    [Tags]  M21_IPMI_1_IPMI_8_Redfish_Host_Get_Account_Credential
     [Template]  Check IPMI Inband Redfish Host Get Account Credential
 
     0xA5

--- a/redfish/test_redfish_boot_device.robot
+++ b/redfish/test_redfish_boot_device.robot
@@ -39,7 +39,6 @@ Verify BMC Redfish Boot Source Override with Enabled Mode As Once
     #BootSourceOverrideEnabled    BootSourceOverrideTarget
     Once                          Hdd
     Once                          Pxe
-    Once                          BiosSetup
 
 
 Verify BMC Redfish Boot Source Override with Enabled Mode As Continuous
@@ -51,7 +50,6 @@ Verify BMC Redfish Boot Source Override with Enabled Mode As Continuous
     #BootSourceOverrideEnabled    BootSourceOverrideTarget
     Continuous                    Hdd
     Continuous                    Pxe
-    Continuous                    BiosSetup
 
 
 Verify BMC Redfish Boot Source Override with Enabled Mode As Disabled

--- a/test_lists/sbmr-acs-linux
+++ b/test_lists/sbmr-acs-linux
@@ -2,6 +2,7 @@
 --include M1_IB_1_IPMI_SSIF_Functionality
 --include M1_OOB_1_IPMI_6_IB_Get_Manager_Info
 --include M1_OOB_1_IPMI_7_IB_Add_User_Account
+--include M1_RAS_1_2_Send_Platform_Error_Record_Command
 
 # M2 Level
 --include M2_IB_1_Redfish_HI_Functionality
@@ -13,19 +14,18 @@
 
 # M21 Level
 --include M21_IB_1_IPMI_SSIF_Capability
---include M21_IPMI_1_Redfish_Host_Certificate_Fingerprint
---include M21_IPMI_1_Redfish_Host_Get_Account_Credential
+--include M21_IPMI_1_IPMI_8_Redfish_Host_Certificate_Fingerprint
+--include M21_IPMI_1_IPMI_8_Redfish_Host_Get_Account_Credential
 --include M21_IPMI_1_IB_Get_Manager_Info
 --include M21_IPMI_1_IB_Add_User_Account
 --include M21_IPMI_2_Send_Platform_Error_Record_Command
 --include M21_IPMI_2_Send_Boot_Progress_Code_Command
 --include M21_IPMI_2_Get_Boot_Progress_Code
 --include M21_PCI_1_Interface_Availability
---include M1_RAS_1_2_Send_Platform_Error_Record_Command
 
 # M21_IPMI1 Redfish HI Credential required only if platform support
---skiponfailure M21_IPMI_1_Redfish_Host_Certificate_Fingerprint
---skiponfailure M21_IPMI_1_Redfish_Host_Get_Account_Credential
+--skiponfailure M21_IPMI_1_IPMI_8_Redfish_Host_Certificate_Fingerprint
+--skiponfailure M21_IPMI_1_IPMI_8_Redfish_Host_Get_Account_Credential
 
 # M21_IPMI2 Arm-defined IPMI Cmd required only if platform support
 --skiponfailure M21_IPMI_2_Send_Platform_Error_Record_Command

--- a/test_lists/sbmr-acs-linux
+++ b/test_lists/sbmr-acs-linux
@@ -13,7 +13,6 @@
 
 # M21 Level
 --include M21_IB_1_IPMI_SSIF_Capability
---include M21_IB_2_IPMI_SSIF_Interrupt
 --include M21_IPMI_1_Redfish_Host_Certificate_Fingerprint
 --include M21_IPMI_1_Redfish_Host_Get_Account_Credential
 --include M21_IPMI_1_IB_Get_Manager_Info

--- a/test_lists/sbmr-acs-oob
+++ b/test_lists/sbmr-acs-oob
@@ -23,13 +23,13 @@
 --include M2_OOB_3_Redfish_Interop_Validator_On_OCP_Server
 --include M2_JTAG_1_2_Interface_Declaration
 --include M2_IO_1_NCSI_Interface_Declaration
+--include M2_RAS_1_2_Function_Declaration
 
 # M21 Level
 --include M21_IPMI_1_Power_Control
 --include M21_IPMI_1_Boot_Device
 --include M21_PCI_1_Redfish_Graphical_Console_Capability
 --include M21_USB_1_Redfish_Virtual_Media_Action_Uri
---include M2_RAS_1_2_Function_Declaration
 
 # Required Only If System Support
 --skiponfailure M2_OOB_3_Redfish_Interop_Validator_On_OCP_Server


### PR DESCRIPTION
Errata(600): SBMR 2.0 Errata
Errata(652): Reduce SSIF SMBAlert requirement to a recommendation
Errata(653): Limit IPMI boot targets requirements