### PR TITLE
Fix M1_UART_2: accept both console and legacy console printk messages

### DIFF
--- a/ipmi/test_ipmi_outband_sol.robot
+++ b/ipmi/test_ipmi_outband_sol.robot
@@ -86,8 +86,10 @@ Verify BSA Compliant UART From Boot Log
 
     # ===== Verify Console TTY is BSA compliant UART =====
     # [    0.960641] printk: console [ttyAMA0] enabled
-    ${line}=  Get Lines Containing String  ${output}  printk: console
-    ${ttyConsole}=  Get Regexp Matches  ${line}  (tty.*)]  1
+    # Accept both:
+    #   printk: console [ttyAMA0] enabled
+    #   printk: legacy console [ttyAMA0] enabled
+    ${ttyConsole}=  Get Regexp Matches  ${output}  (?m)printk: (?:legacy )?console \[(tty[^\]]+)\] enabled  1
 
     Dictionary Should Contain Key  ${spcr_tty_lists}  ${ttyConsole}[0]
     ...  msg=Failure: Console UART not a BSA compliant UART


### PR DESCRIPTION
## Summary
The M1_UART_2 test in `test_ipmi_outband_sol.robot` currently fails on
systems where the kernel enables the UART console in "legacy" mode.
Such systems produce the log line:

  printk: legacy console [ttyAMA0] enabled

instead of:

  printk: console [ttyAMA0] enabled

Although the console is fully functional and BSA-compliant, the test
does not detect it and reports a false failure.

## Changes
- Updated the regex in Verify BSA Compliant UART From Boot Log to
  accept both console and legacy console printk messages.
- Extracts the TTY device (e.g. ttyAMA0) from either case.

## Impact
- Prevents false negatives when only a legacy console is present.
- Maintains compliance verification logic: the console TTY is still
  checked against the ACPI SPCR table for BSA compliance.
- No effect on systems already passing with the non-legacy message.

## Issue
Fixes #36