### PR TITLE
Add M5_OOB_1 (Test Redfish BIOS Settings Resource support)

### DIFF
--- a/config
+++ b/config
@@ -56,8 +56,11 @@
 -v M5_IB_1_2_Interface_Declaration:0
 -v M5_SB_1_Interface_Declaration:0
 -v M5_IO_1_Interface_Declaration:0
--v M5_OOB_1_Interface_Declaration:0
 -v M5_HS_1_2_Interface_Declaration:0
+# Add user-controlled flag to decide whether BIOS settings are exposed and the test should run.
+# 0 means BIOS settings are not exposed and the test will be skipped.
+# 1 means BIOS settings are exposed and the test will be executed.
+-v M5_OOB_1_EXPOSE_BIOS_SETTINGS_SUPPORT:0
 
 ##### Debug : Redfish Mockup Creator #####
 #--include Test_BMC_Redfish_Using_Redfish_Mockup_Creator

--- a/docs/arm_sbmr_testcase_checklist.rst
+++ b/docs/arm_sbmr_testcase_checklist.rst
@@ -187,7 +187,11 @@ The checklist indicates whether each test is executed via automation or requires
 +------------+-------+------------+-----------------+--------------------+----------------------------------------------------------------------+
 | BMC-IO     | M5a   | M5_IO_1    | No              | - Self Declaration | - M5_IO_1_Interface_Declaration*                                     |
 +------------+-------+------------+-----------------+--------------------+----------------------------------------------------------------------+
-| OOB        | M5a   | M5_OOB_1   | No              | - Self Declaration | - M5_OOB_1_Interface_Declaration* (conditional)                      |
+| OOB        | M5a   | M5_OOB_1   | yes             | - OOB              | - M5_OOB_1_Redfish_BIOS_Settings_Resource* (conditional)             |
+|            |       |            |                 |                    |                                                                      |
+|            |       |            |                 |                    | User should declare whether the server platform supports             |
+|            |       |            |                 |                    | user-accessible BIOS settings using                                  |
+|            |       |            |                 |                    | M5_OOB_1_EXPOSE_BIOS_SETTINGS_SUPPORT flag in config.                |
 +------------+-------+------------+-----------------+--------------------+----------------------------------------------------------------------+
 | Host-SatMC | M5a   | M5_HS_1    | No              | - Self Declaration | - M5_HS_1_2_Interface_Declaration* (conditional)                     |
 +------------+-------+------------+-----------------+--------------------+----------------------------------------------------------------------+

--- a/host/declaration_for_sbmr_interface.robot
+++ b/host/declaration_for_sbmr_interface.robot
@@ -125,14 +125,6 @@ Declaration For BMC M5_IO Interface Support
     [Template]  Verify Declaration
     ${M5_IO_1_Interface_Declaration}  M5_IO_1
 
-
-Declaration For BMC M5_OOB Interface Support
-    [Documentation]  Declaration for BMC M5_OOB interface support
-    [Tags]  M5_OOB_1_Interface_Declaration
-    [Template]  Verify Declaration
-    ${M5_OOB_1_Interface_Declaration}  M5_OOB_1
-
-
 Declaration For BMC M5_HS Interface Support
     [Documentation]  Declaration for BMC M5_HS interface support
     [Tags]  M5_HS_1_2_Interface_Declaration

--- a/lib/resource.robot
+++ b/lib/resource.robot
@@ -161,8 +161,8 @@ ${M4_IO_1_3_Interface_Declaration}       0
 ${M5_IB_1_2_Interface_Declaration}       0
 ${M5_SB_1_Interface_Declaration}         0
 ${M5_IO_1_Interface_Declaration}         0
-${M5_OOB_1_Interface_Declaration}        0
 ${M5_HS_1_2_Interface_Declaration}       0
+${M5_OOB_1_EXPOSE_BIOS_SETTINGS_SUPPORT}  0
 
 *** Keywords ***
 Get Inventory Schema

--- a/redfish/test_redfish_bios_settings.robot
+++ b/redfish/test_redfish_bios_settings.robot
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test Redfish BIOS Settings Resource support
+Resource            ../lib/resource.robot
+Resource            ../lib/bmc_redfish_resource.robot
+Resource            ../lib/bmc_redfish_utils.robot
+Library             Collections
+
+Suite Setup         Suite Setup Execution
+Suite Teardown      Suite Teardown Execution
+Test Setup          Test Setup Execution
+Test Teardown       Test Teardown Execution
+
+
+*** Test Cases ***
+Verify BMC Redfish BIOS Settings Resource
+    [Documentation]  Test Redfish BIOS Settings Resource support
+    [Tags]  M5_OOB_1_Redfish_BIOS_Settings_Resource
+
+    Skip If BIOS Settings Unsupported
+
+    ${bios_uri}=  Set Variable  /redfish/v1/Systems/${SYSTEM_ID}/Bios
+
+    ${redfish_settings}=  Redfish.Get Attribute  ${bios_uri}  @Redfish.Settings
+    Should Not Be Empty  ${redfish_settings}
+    ...  BIOS resource exists but Redfish Settings is missing.
+
+    ${settings_object}=  Get From Dictionary  ${redfish_settings}  SettingsObject
+    ${settings_uri}=  Get From Dictionary  ${settings_object}  @odata.id
+    Should Not Be Empty  ${settings_uri}
+    ...  BIOS resource exists but Redfish SettingsObject URI is missing.
+
+    ${bios_settings}=  Redfish.Get Properties  ${settings_uri}
+    Should Not Be Empty  ${bios_settings}
+    ...  BIOS SettingsObject URI is not accessible: ${settings_uri}
+
+    Dictionary Should Contain Key  ${bios_settings}  Attributes
+    ...  BIOS SettingsObject is accessible but Attributes property is missing.
+
+
+*** Keywords ***
+Skip If BIOS Settings Unsupported
+    [Documentation]  Skip BIOS settings tests when the platform does not declare support.
+
+    Skip If  '${M5_OOB_1_EXPOSE_BIOS_SETTINGS_SUPPORT}' != '1'
+    ...  M5_OOB_1 not applicable: platform does not declare user-accessible BIOS settings support.
+
+
+Suite Setup Execution
+    [Documentation]  Do suite setup.
+
+    Redfish.Login
+    Delete All Redfish Sessions
+
+Suite Teardown Execution
+    [Documentation]  Do suite teardown.
+
+    Redfish.Login
+    Delete All Redfish Sessions
+
+Test Setup Execution
+    [Documentation]  Do test setup.
+
+    Redfish.Login
+
+Test Teardown Execution
+    [Documentation]  Do test teardown.
+
+    Redfish.Logout

--- a/test_lists/sbmr-acs-oob
+++ b/test_lists/sbmr-acs-oob
@@ -48,7 +48,7 @@
 --include M5_IB_1_2_Interface_Declaration
 --include M5_SB_1_Interface_Declaration
 --include M5_IO_1_Interface_Declaration
---include M5_OOB_1_Interface_Declaration
+--include M5_OOB_1_Redfish_BIOS_Settings_Resource
 --include M5_HS_1_2_Interface_Declaration
 
 # Required Only If System Support
@@ -61,7 +61,6 @@
 --skiponfailure M3_JTAG_1_2_Interface_Declaration
 --skiponfailure M3_IO_1_2_Interface_Declaration
 --skiponfailure M4_IO_1_3_Interface_Declaration
---skiponfailure M5_OOB_1_Interface_Declaration
 --skiponfailure M5_HS_1_2_Interface_Declaration
 --skiponfailure M21_PCI_1_Redfish_Graphical_Console_Capability
 --skiponfailure M5_IB_1_2_Interface_Declaration


### PR DESCRIPTION
 -Add user-controlled M5_OOB_1_EXPOSE_BIOS_SETTINGS_SUPPORT flag to decide whether BIOS settings are exposed.
 -Include the BIOS settings test tag in the OOB test list.


Change-Id: Iefd8e6c30d25cecedd5b33f1fc138c37ad32e78a