### PR TITLE
Update Redfish DMTF validator revisions

### DIFF
--- a/redfish/dmtf_tools/Redfish_Interop_Validator.robot
+++ b/redfish/dmtf_tools/Redfish_Interop_Validator.robot
@@ -29,7 +29,7 @@ Suite Teardown     Suite Teardown Execution
 ${DEFAULT_PYTHON}  python3
 ${rsv_dir_path}    Redfish-Interop-Validator
 ${rsv_github_url}  https://github.com/DMTF/Redfish-Interop-Validator.git
-${rsv_revision}    2.1.3
+${rsv_revision}    2.3.5
 ${cmd_str_master}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}RedfishInteropValidator.py
 ...                --ip https://${BMC_HOST}:${HTTPS_PORT} --authtype=Session -u ${BMC_USERNAME}
 ...                -p ${BMC_PASSWORD} --logdir ${OUTPUT_DIR}${/}redfish-interop-validator
@@ -48,7 +48,7 @@ Test BMC Redfish Using Redfish Interop Validator On OCP Baseline Profile
     [Template]  Run Redfish Interop Validator With Profile
 
     # profile
-    HWMgmt${/}OCPBaselineHardwareManagement.v1_1_0.json
+    OCPBaselineHardwareManagement.v1_1_1.json
 
 
 Test BMC Redfish Using Redfish Interop Validator On OCP Server Profile

--- a/redfish/dmtf_tools/Redfish_Protocol_Validator.robot
+++ b/redfish/dmtf_tools/Redfish_Protocol_Validator.robot
@@ -26,7 +26,7 @@ Resource           ../../lib/dmtf_tools_utils.robot
 ${DEFAULT_PYTHON}  python3
 ${rsv_dir_path}    Redfish-Protocl-Validator
 ${rsv_github_url}  https://github.com/DMTF/Redfish-Protocol-Validator.git
-${rsv_revision}    1.2.5
+${rsv_revision}    1.3.0
 ${cmd_str_master}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}rf_protocol_validator.py
 ...                -r https://${BMC_HOST}:${HTTPS_PORT} -u ${BMC_USERNAME} -p ${BMC_PASSWORD}
 ...                --report-dir ${EXECDIR}${/}logs${/}redfish-protocol-validator

--- a/redfish/dmtf_tools/Redfish_Service_Validator.robot
+++ b/redfish/dmtf_tools/Redfish_Service_Validator.robot
@@ -32,7 +32,7 @@ Suite Teardown     Suite Teardown Execution
 ${DEFAULT_PYTHON}  python3
 ${rsv_dir_path}    Redfish-Service-Validator
 ${rsv_github_url}  https://github.com/DMTF/Redfish-Service-Validator.git
-${rsv_revision}    2.5.1
+${rsv_revision}    3.1.4
 ${cmd_str_master}  ${DEFAULT_PYTHON} ${rsv_dir_path}${/}RedfishServiceValidator.py
 ...                --ip https://${BMC_HOST}:${HTTPS_PORT} --authtype=Session -u ${BMC_USERNAME}
 ...                -p ${BMC_PASSWORD} --logdir ${OUTPUT_DIR}${/}redfish-service-validator

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ robotframework-lint
 jsonschema==3.2.0
 beautifulsoup4
 lxml
+openpyxl


### PR DESCRIPTION
-Redfish Service Validator 2.5.1 -> 3.1.4
-Redfish Protocol Validator 1.2.5 -> 1.3.0
-Redfish Interop Validator 2.1.3 -> 2.3.5
-OCP baseline profile update to OCPBaselineHardwareManagement.v1_1_1.json


Change-Id: I4aa87f4073ba3079327e0ef5c00a12361bf203e7