### PR TITLE
Replace fixed power-off/on delay with status polling

### DIFF
--- a/ipmi/test_ipmi_outband_boot_select.robot
+++ b/ipmi/test_ipmi_outband_boot_select.robot
@@ -58,7 +58,7 @@ Suite Setup Execution
     [documentation]  Do suite setup tasks.
 
     Run External IPMI Standard Command  chassis power off
-    Sleep  10 sec
+    Wait For Chassis Power Off Via IPMI
 
 
 Suite Teardown Execution

--- a/ipmi/test_ipmi_outband_power_control.robot
+++ b/ipmi/test_ipmi_outband_power_control.robot
@@ -66,7 +66,7 @@ Suite Setup Execution
     [Documentation]  Do the post test setup.
 
     Run External IPMI Standard Command  chassis power off
-    Sleep  10 sec
+    Wait For Chassis Power Off Via IPMI
 
     Run External IPMI Standard Command  chassis bootdev none ${IPMI_OPTIONS_EFIBOOT}
 

--- a/ipmi/test_ipmi_outband_sol.robot
+++ b/ipmi/test_ipmi_outband_sol.robot
@@ -109,7 +109,7 @@ Suite Setup Execution
     [Documentation]  Do the post test setup.
 
     Run External IPMI Standard Command  chassis power off
-    Sleep  10 sec
+    Wait For Chassis Power Off Via IPMI
 
     Run External IPMI Standard Command  chassis bootdev none ${IPMI_OPTIONS_EFIBOOT}
 

--- a/lib/ipmi_client.robot
+++ b/lib/ipmi_client.robot
@@ -305,6 +305,8 @@ Initiate Host Boot Via External IPMI
     ${output}=  Run External IPMI Standard Command  chassis power on
     Should Not Contain  ${output}  Error
 
+    Wait For Chassis Power On Via IPMI
+
     Run Keyword If  '${wait}' == '${0}'  Return From Keyword
     Wait Until Keyword Succeeds  10 min  10 sec  Is Host Running
 
@@ -632,3 +634,44 @@ Check IPMI SOL Output Content
     ${output}=  OperatingSystem.Get File  ${file_path}  encoding_errors=ignore
     Should Match Regexp  ${output}  ${data}  case_insensitive=True
 
+Wait For Chassis Power Off Via IPMI
+    [Documentation]  Wait until chassis power status reports off.
+    [Arguments]  ${max_cycles}=30  ${interval}=1 sec
+
+    Wait For Chassis Power State Via IPMI
+    ...  off  ${max_cycles}  ${interval}
+
+
+Wait For Chassis Power On Via IPMI
+    [Documentation]  Wait until chassis power status reports on.
+    [Arguments]  ${max_cycles}=10  ${interval}=1 sec
+
+    Wait For Chassis Power State Via IPMI
+    ...  on  ${max_cycles}  ${interval}
+
+
+Wait For Chassis Power State Via IPMI
+    [Documentation]  Wait until chassis reports the expected power state.
+    [Arguments]  ${expected_state}  ${max_cycles}  ${interval}=1 sec
+
+    ${status}=  Set Variable  ${EMPTY}
+
+    FOR  ${cycle}  IN RANGE  ${max_cycles}
+        ${cycle_number}=  Evaluate  ${cycle} + 1
+        ${status}=  Run External IPMI Standard Command  chassis power status
+        Log  Chassis power status check ${cycle_number}/${max_cycles}: ${status}
+
+        ${state_reached}=  Run Keyword And Return Status
+        ...  Should Contain  ${status}  Chassis Power is ${expected_state}
+
+        Run Keyword If  ${state_reached}
+        ...  Run Keywords
+        ...  Log  Chassis reached power-${expected_state} state on cycle ${cycle_number}.  console=True
+        ...  AND
+        ...  Return From Keyword
+
+        Sleep  ${interval}
+    END
+
+    Log  Chassis did not reach power-${expected_state} state after ${max_cycles} cycles. Final status: ${status}  level=ERROR
+    Fail  Chassis power is not ${expected_state} after ${max_cycles} status checks.


### PR DESCRIPTION
 -Poll the chassis power status after issuing power-off/on instead of using a fixed delay, allowing IPMI test setup to proceed as soon as the chassis reports off/on.

Fixes: #58 

Change-Id: I16bae0a7dd51d6060b19b4579f8126a65790e514